### PR TITLE
Safely Set Project Environment Variables

### DIFF
--- a/cmlbootstrap/CMLBootstrap.py
+++ b/cmlbootstrap/CMLBootstrap.py
@@ -541,6 +541,34 @@ class CMLBootstrap:
         else:
             logging.debug("Environment variable created")
         return res.status_code
+
+    def get_environment_variables(self, params):
+        """Get the project level environment variables
+
+        Arguments:
+            params {dict} -- None needed.
+
+        Returns:
+            dict -- [dictionary containing project level environment variables]
+        """
+        create_environment_variable_endpoint = "/".join([self.host, "api/v1/projects",
+                                                         self.username, self.project_name, "environment"])
+    
+        res = requests.get(
+                create_environment_variable_endpoint,
+                headers={"Content-Type": "application/json"},
+                auth=(self.api_key, ""),
+                data=json.dumps(params)
+        )
+        
+        response = res.json()
+        if (res.status_code != 200):
+            logging.error(response["message"])
+            logging.error(response)
+        else:
+            logging.debug("Environment variables retrieved")
+
+        return response
     
     def add_project_editor(self, params):
         add_project_editor_endpoint = "/".join([self.host, "api/v1/projects",

--- a/cmlbootstrap/CMLBootstrap.py
+++ b/cmlbootstrap/CMLBootstrap.py
@@ -507,22 +507,6 @@ class CMLBootstrap:
         return response
 
     def create_environment_variable(self, params):
-        create_environment_variable_endpoint = "/".join([self.host, "api/v1/projects",
-                                                         self.username, self.project_name, "environment"])
-        res = requests.put(
-            create_environment_variable_endpoint,
-            headers={"Content-Type": "application/json"},
-            auth=(self.api_key, ""),
-            data=json.dumps(params)
-        )
-        #response = res.json()
-        if (res.status_code != 204):
-            logging.error("Reponse code was " + res.status_code)
-        else:
-            logging.debug("Environment variable created")
-        return res.status_code
-
-    def add_environment_variable(self, params):
         """Add project level environment variables
 
         Arguments:

--- a/cmlbootstrap/CMLBootstrap.py
+++ b/cmlbootstrap/CMLBootstrap.py
@@ -1,6 +1,7 @@
 import requests
 import json
 import logging
+import os
 
 
 class CMLBootstrap:
@@ -513,6 +514,26 @@ class CMLBootstrap:
             headers={"Content-Type": "application/json"},
             auth=(self.api_key, ""),
             data=json.dumps(params)
+        )
+        #response = res.json()
+        if (res.status_code != 204):
+            logging.error("Reponse code was " + res.status_code)
+        else:
+            logging.debug("Environment variable created")
+        return res.status_code
+
+    def add_environment_variable(self, params):
+
+        env_vars = dict(os.environ)
+        env_vars.update(params)
+
+        create_environment_variable_endpoint = "/".join([self.host, "api/v1/projects",
+                                                         self.username, self.project_name, "environment"])
+        res = requests.put(
+            create_environment_variable_endpoint,
+            headers={"Content-Type": "application/json"},
+            auth=(self.api_key, ""),
+            data=json.dumps(env_vars)
         )
         #response = res.json()
         if (res.status_code != 204):

--- a/cmlbootstrap/CMLBootstrap.py
+++ b/cmlbootstrap/CMLBootstrap.py
@@ -523,8 +523,16 @@ class CMLBootstrap:
         return res.status_code
 
     def add_environment_variable(self, params):
+         """Add project level environment variables
 
-        env_vars = dict(os.environ)
+        Arguments:
+            params {dict} -- [dictionary containing new environment variables]
+
+        Returns:
+            res.status_code
+        """
+
+        env_vars = self.get_environment_variables({})
         env_vars.update(params)
 
         create_environment_variable_endpoint = "/".join([self.host, "api/v1/projects",

--- a/cmlbootstrap/CMLBootstrap.py
+++ b/cmlbootstrap/CMLBootstrap.py
@@ -523,7 +523,7 @@ class CMLBootstrap:
         return res.status_code
 
     def add_environment_variable(self, params):
-         """Add project level environment variables
+        """Add project level environment variables
 
         Arguments:
             params {dict} -- [dictionary containing new environment variables]
@@ -531,7 +531,6 @@ class CMLBootstrap:
         Returns:
             res.status_code
         """
-
         env_vars = self.get_environment_variables({})
         env_vars.update(params)
 
@@ -548,6 +547,7 @@ class CMLBootstrap:
             logging.error("Reponse code was " + res.status_code)
         else:
             logging.debug("Environment variable created")
+
         return res.status_code
 
     def get_environment_variables(self, params):

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,9 +12,9 @@ Classes
         username (str): Current username.
         api_key (str): API key.
         project_name (str): Project name.
-
+    
     ### Methods
-
+    
     `create_application(self, params)`
     :   Create an Application
         
@@ -23,7 +23,7 @@ Classes
         
         Returns:
             [dict] -- [dictionary containing job details]
-
+    
     `create_job(self, params)`
     :   Create a job
         
@@ -32,7 +32,7 @@ Classes
         
         Returns:
             [dict] -- [dictionary containing job details]
-
+    
     `create_model(self, params)`
     :   Create a model
         
@@ -41,7 +41,7 @@ Classes
         
         Returns:
             [dict] -- [dictionary containing model details]
-
+    
     `delete_application(self, application_id, params)`
     :   Delete application given id
         
@@ -51,7 +51,7 @@ Classes
         
         Returns:
             None -- None
-
+    
     `delete_job(self, job_id, params)`
     :   Delete a job given its id
         
@@ -60,7 +60,7 @@ Classes
             job_id {str} -- id for job to be deleted
         Returns:
             [dict] -- [None. delete endpoint does not return a value]
-
+    
     `delete_model(self, params)`
     :   Delete a project given its id
         
@@ -69,7 +69,7 @@ Classes
         
         Returns:
             dict -- Nothing.
-
+    
     `get_application(self, app_id, params)`
     :   Get details for an application
         
@@ -79,7 +79,7 @@ Classes
         
         Returns:
             {dict} -- dictionary of application details
-
+    
     `get_applications(self, params)`
     :   Get list of applications within current project
         
@@ -88,7 +88,7 @@ Classes
         
         Returns:
             list -- list of current applications
-
+    
     `get_default_engine(self, params)`
     :   Get the default engine for the given project
         
@@ -97,7 +97,7 @@ Classes
         
         Returns:
             dict -- [dictionary containing default engine details]
-
+    
     `get_jobs(self, params)`
     :   Return a list of jobs associated with the given project
         
@@ -106,10 +106,10 @@ Classes
         
         Returns:
             list -- List of jobs
-
+    
     `get_model(self, params)`
     :
-
+    
     `get_models(self, params)`
     :   Return a list of models associated with the given project
         
@@ -118,7 +118,7 @@ Classes
         
         Returns:
             list -- List of models
-
+    
     `get_project(self, params)`
     :   Get details for a given project
         
@@ -127,7 +127,7 @@ Classes
         
         Returns:
             [dict] -- [dictionary containing project details]
-
+    
     `get_user(self, params)`
     :   Get details for a given user
         
@@ -136,7 +136,7 @@ Classes
         
         Returns:
             [dict] -- [dictionary containing user details]
-
+    
     `run_experiment(self, params)`
     :   Run an experiment
         
@@ -145,7 +145,7 @@ Classes
         
         Returns:
             [dict] -- []
-
+    
     `start_job(self, job_id, params)`
     :   Start a job
         
@@ -155,7 +155,7 @@ Classes
         
         Returns:
             [dict] -- [ ]
-
+    
     `stop_job(self, job_id, params)`
     :   Stop a job
         

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,3 +165,21 @@ Classes
         
         Returns:
             [dict] -- []
+            
+    `get_environment_variables(self, params)`
+    :   Get the project level environment variables
+        
+        Arguments:
+            params {dict} -- None
+        
+        Returns:
+            [dict] -- []
+            
+    `create_environment_variable(self, params)`
+    :   Add project level environment variables
+        
+        Arguments:
+            params {dict} -- [dict containing environment variable key pairs]
+        
+        Returns:
+            [dict] -- []


### PR DESCRIPTION
# Purpose

This PR introduces functionality to create new environment variables via the CMLBootstrapAPI _**without**_ unsetting existing environment variables.

# How it works

- A new method has been added called `.get_environment_variables()` that retrieves _project level_ env variables.
- Another method has been added called `.add_environment_variable()` that first retrieves existing existing project level vars, and then appends new variables to them before submitting the API request.

